### PR TITLE
Fix queryNames() to check also stdout to contain '(NotFound)' message

### DIFF
--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -1505,7 +1505,7 @@ class OpenShiftDSL implements Serializable {
                 r.failIf("Unable to retrieve object names: " + this.toString());
             } else {
                 r = (OcAction.OcActionResult)script._OcAction(buildCommonArgs("get", selectionArgs(), null, "-o=name"));
-                if (r.status != 0 && r.err.contains("(NotFound)")) {
+                if (r.status != 0 && (r.err.contains("(NotFound)") || r.out.contains("(NotFound)"))) {
                     return new ArrayList<String>();
                 } else {
                     r.failIf("Unable to retrieve object names: " + this.toString());


### PR DESCRIPTION
Hi,

Fix : https://github.com/openshift/jenkins-client-plugin/issues/376

Doesn't fix the root cause (oc help command), but check if the string '(NotFound)' also appear on stdout.

Tested with OC 4.11

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

